### PR TITLE
Fix to non 200 error code replies

### DIFF
--- a/steembase/http_client.py
+++ b/steembase/http_client.py
@@ -179,6 +179,13 @@ class HttpClient(object):
             if response.status not in tuple(
                     [*response.REDIRECT_STATUSES, 200]):
                 logger.info('non 200 response:%s', response.status)
+                # try switching nodes before giving up
+                if _ret_cnt > 2:
+                    time.sleep(5 * _ret_cnt)
+                if _ret_cnt > 10:
+                    return self._return(response=response.status)
+                self.next_node()
+                return self.exec(name, *args, return_with_args=return_with_args, _ret_cnt=_ret_cnt + 1)
 
             return self._return(
                 response=response,


### PR DESCRIPTION
Proposal to implement similar error checking logic when a non 200 error code is received. This will reduce/avoid empty responses.
In the current state, there is a loop to infinity condition when using the Steemd function "get_blocks" if the active RPC node persistently returns a non 200 error code. 

For many other functions performing an API call, this should reduce the number of exceptions thrown due to empty responses.

Please review. 
Have seen no negative effects in my tests so far.